### PR TITLE
Fix copy path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:8.2-apache
-COPY server/ /var/www/server
+COPY ./server/ /var/www/html/
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 


### PR DESCRIPTION
The default path which the php-apache image serves is /var/www/html/ so we need to copy our php files there.

Before the Change Apache could find anything to serve: AH01276: Cannot serve directory /var/www/html/: No matching DirectoryIndex (index.php,index.html) found[...]