### PR TITLE
Docker patch and bugfix in API.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ COPY ./server/ /var/www/html/
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-EXPOSE 80
+RUN sed -ri -e 's/80/8100/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+
+EXPOSE 8100

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ In order to run micro-gpodder-server with Docker you only need to build the `Doc
 services:
   gpodder:
     container_name: gPodder
+    user: <uid>:<gid>
     build:
       context: ./micro-gpodder-server
       dockerfile: Dockerfile

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ const TITLE = 'My awesome GPodder server';
 
 // Set to the URL where the server is hosted
 const BASE_URL = 'https://gpodder.mydomain.tld/me/';
+?>
 ```
 
 ## Configuring your podcast client

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ services:
     volumes:
       - type: bind
         source: ~/docker_files/gpodder/data
-        target: /var/www/server/data
+        target: /var/www/html/data
     hostname: gpodder.example.org
     ports:
-      - 80:80
+      - 8100:8100
 ```
 
 ### Configuration

--- a/server/inc/API.php
+++ b/server/inc/API.php
@@ -135,7 +135,7 @@ class API
 			$this->error(401, 'No username or password provided');
 		}
 
-		$this->requireAuth();
+		$this->requireAuth(null);
 
 		$this->error(200, 'Logged in!');
 	}


### PR DESCRIPTION
I made changes to the Dockerfile so that when run as a container, this server outputs to an unprivileged port. This allows the container to run as a non-root user, so passing in a `data` folder doesn't require changing permissions on the host system. Also updated the docker-compose example to reflect these changes.

Added an explicit `null` to line 138 to suppress an error saying `requireAuth`  was missing a required argument.

This should fix #18 