### PR TITLE
Support DATA_ROOT override with env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to run micro-gpodder-server with Docker you only need to build the `Doc
 
 ### Configuration
 
-You can create a `config.local.php` in the `data` directory, defining configuration constants:
+You can create a `config.local.php` in the `data` directory (overridable with the `DATA_ROOT` environment variable), defining configuration constants:
 
 ```
 <?php

--- a/server/index.php
+++ b/server/index.php
@@ -28,7 +28,7 @@ set_exception_handler(function ($e) {
 	exit;
 });
 
-define('DATA_ROOT', __DIR__ . '/data');
+define('DATA_ROOT', getenv('DATA_ROOT') ?: __DIR__ . '/data');
 
 if (!file_exists(DATA_ROOT)) {
 	mkdir(DATA_ROOT);


### PR DESCRIPTION
My use-case was running with a read-only web root (in the Nix store).